### PR TITLE
:FC-1097: :art: Routine maintenance for Open-Source-Libraries

### DIFF
--- a/src/controller/create.controller.ts
+++ b/src/controller/create.controller.ts
@@ -48,9 +48,8 @@ export class CreateController {
    */
   public async createFunction(functionParameters = {}): Promise<void> {
     try {
-      const missingParameters = await this.checkAndAskForMissingFunctionParameters(
-        functionParameters,
-      );
+      const missingParameters =
+        await this.checkAndAskForMissingFunctionParameters(functionParameters);
 
       const functionConfig: IFunctionConfig = {
         ...functionParameters,
@@ -121,9 +120,8 @@ export class CreateController {
    */
   public async createSchedule(scheduleParameters = {}): Promise<void> {
     try {
-      const missingParameters = await this.checkAndAskForMissingScheduleParameters(
-        scheduleParameters,
-      );
+      const missingParameters =
+        await this.checkAndAskForMissingScheduleParameters(scheduleParameters);
 
       const scheduleConfig: IScheduleConfig = {
         ...missingParameters,
@@ -159,9 +157,9 @@ export class CreateController {
     }
 
     const faasService = await factory.get();
-    const deployedLambdas = (
-      await faasService.getAllLambdas()
-    ).filter(({ state }) => ['Productive', 'Modified'].includes(state));
+    const deployedLambdas = (await faasService.getAllLambdas()).filter(
+      ({ state }) => ['Productive', 'Modified'].includes(state),
+    );
     scheduleConfig.lambdaUUID = deployedLambdas.find(
       ({ name }) => functionName === name,
     )?.uuid;

--- a/src/controller/deployment/deploy.controller.ts
+++ b/src/controller/deployment/deploy.controller.ts
@@ -38,9 +38,8 @@ export class DeployController extends DeploymentController {
     inputFlags,
   }: IDeployConfig): Promise<void> {
     try {
-      const functionsToDeploy: ILambda[] = await this.collectLambdaInformationForAllLambdas(
-        lambdaFunctions,
-      );
+      const functionsToDeploy: ILambda[] =
+        await this.collectLambdaInformationForAllLambdas(lambdaFunctions);
 
       let confirmedFunctionsToDeploy: ILambda[] = [];
       if (inputFlags?.yes) {

--- a/src/controller/deployment/undeploy.controller.ts
+++ b/src/controller/deployment/undeploy.controller.ts
@@ -38,9 +38,8 @@ export class UndeployController extends DeploymentController {
     inputFlags,
   }: IUndeployConfig): Promise<void> {
     try {
-      const functionsToUndeploy: ILambda[] = await this.collectLambdaInformationForAllLambdas(
-        lambdaFunctions,
-      );
+      const functionsToUndeploy: ILambda[] =
+        await this.collectLambdaInformationForAllLambdas(lambdaFunctions);
 
       let confirmedFunctionsToUndeploy: ILambda[] = [];
       if (inputFlags?.yes) {

--- a/src/controller/init.controller.ts
+++ b/src/controller/init.controller.ts
@@ -59,9 +59,8 @@ export class InitController {
     try {
       this.update = update;
       const packageManager = this.determinePackageManager();
-      const needDependencyInstallation: boolean = this.needDependencyInstallation(
-        packageManager,
-      );
+      const needDependencyInstallation: boolean =
+        this.needDependencyInstallation(packageManager);
       await this.initView.showInitialiseTaskList({
         packageManager,
         needDependencyInstallation,

--- a/src/controller/invoke.controller.ts
+++ b/src/controller/invoke.controller.ts
@@ -53,9 +53,8 @@ export class InvokeController {
         await this.initController.init({ update: true });
       }
 
-      const localLambdaInformation = this.fileService.collectLocalLambdaInformation(
-        lambdaFunctions,
-      );
+      const localLambdaInformation =
+        this.fileService.collectLocalLambdaInformation(lambdaFunctions);
       [this.lambdaToInvoke] = localLambdaInformation;
       if (inputFlags?.local) {
         const indexPath = join(

--- a/src/controller/login.controller.ts
+++ b/src/controller/login.controller.ts
@@ -138,12 +138,11 @@ export class LoginController {
       displayAccountId?: boolean;
     } = { showBanner: false, displayAccountId: false },
   ): Promise<void> {
-    const promptAnswer: IPromptAnswer = await this.loginView.askForUsernameAndPassword(
-      {
+    const promptAnswer: IPromptAnswer =
+      await this.loginView.askForUsernameAndPassword({
         password,
         username,
-      },
-    );
+      });
 
     try {
       const response: ILoginResponse = await this.loginService.login({
@@ -198,9 +197,8 @@ export class LoginController {
         };
       }
 
-      const { token, userId, username, csrf, sessionId } = this.tempFile[
-        activeAccountId
-      ];
+      const { token, userId, username, csrf, sessionId } =
+        this.tempFile[activeAccountId];
       if (
         validToken ||
         (await this.loginService.isTokenValid({

--- a/src/controller/logout.controller.ts
+++ b/src/controller/logout.controller.ts
@@ -49,10 +49,11 @@ export class LogoutController {
     if (inputFlags.accountId) {
       selectedAccountId = inputFlags.accountId;
     } else {
-      const answer: IPromptAnswer = await this.logoutView.showAccountIdSelection(
-        accountIds,
-        inputFlags.delete,
-      );
+      const answer: IPromptAnswer =
+        await this.logoutView.showAccountIdSelection(
+          accountIds,
+          inputFlags.delete,
+        );
       selectedAccountId = answer.accountId;
     }
 

--- a/src/controller/push.controller.ts
+++ b/src/controller/push.controller.ts
@@ -47,9 +47,8 @@ export class PushController {
         lambdaFunctions = this.fileService.getFunctionsDirectories();
       }
 
-      const localLambdaInformation = this.fileService.collectLocalLambdaInformation(
-        lambdaFunctions,
-      );
+      const localLambdaInformation =
+        this.fileService.collectLocalLambdaInformation(lambdaFunctions);
       const localLambdaNames = localLambdaInformation.map((e) => e.name);
       const faasService = await factory.get();
 

--- a/test/service/faas.service.test.ts
+++ b/test/service/faas.service.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-throw-literal */
+/* eslint-disable node/no-unsupported-features/node-builtins */
 import * as os from 'os';
 import { Readable } from 'stream';
 import { FaasService } from '../../src/service/faas.service';

--- a/test/service/file.service.test.ts
+++ b/test/service/file.service.test.ts
@@ -108,7 +108,7 @@ describe('file service', () => {
   it('should throw an error while getting path to function', () => {
     fs.ensureDirSync(join(testDir, 'functions'));
 
-    const functionName = (undefined as unknown) as string;
+    const functionName = undefined as unknown as string;
 
     expect(() => {
       fileService.getPathToFunction(functionName);


### PR DESCRIPTION
The changes contain prettier/prettier issue fixes and 'stream.Readable.from' issues i found when i was updating the libraries
` 342:16  error  The 'stream.Readable.from' is not supported until Node.js 12.3.0 (backported: ^10.17.0). The configured version range is '>=10.5.0'  node/no-unsupported-features/node-builtins`