### PR TITLE
:FC-1097: :bug: lodash.template module missing fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14735,7 +14735,7 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.int.liveperson.net:443/artifactory/api/npm/lp-npm-virtual/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.camelcase": {
@@ -14822,7 +14822,7 @@
     },
     "lodash.template": {
       "version": "4.5.0",
-      "resolved": "https://artifactory.int.liveperson.net:443/artifactory/api/npm/lp-npm-virtual/lodash.template/-/lodash.template-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
@@ -14831,7 +14831,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
-      "resolved": "https://artifactory.int.liveperson.net:443/artifactory/api/npm/lp-npm-virtual/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14735,7 +14735,7 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://artifactory.int.liveperson.net:443/artifactory/api/npm/lp-npm-virtual/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.camelcase": {
@@ -14822,8 +14822,8 @@
     },
     "lodash.template": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "resolved": "https://artifactory.int.liveperson.net:443/artifactory/api/npm/lp-npm-virtual/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -14831,8 +14831,8 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "resolved": "https://artifactory.int.liveperson.net:443/artifactory/api/npm/lp-npm-virtual/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
@@ -16408,6 +16408,7 @@
             "lodash": "^4.17.15",
             "run-async": "^2.4.0",
             "rxjs": "^6.5.3",
+            "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0",
             "through": "^2.3.6"
           },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",
     "got": "^10.7.0",
+    "hpagent": "0.1.2",
     "inquirer": "^8.0.0",
     "js-yaml": "^4.0.0",
     "jsforce": "^1.9.3",
@@ -33,6 +34,7 @@
     "latest-version": "^6.0.0",
     "listr": "^0.14.3",
     "lodash": "^4.17.21",
+    "lodash.template": "^4.5.0",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.28",
     "node-emoji": "^1.10.0",
@@ -42,8 +44,7 @@
     "semver": "^7.2.1",
     "set-interval-async": "^1.0.30",
     "systeminformation": "^5.3.1",
-    "uuid": "8.3.2",
-    "hpagent": "0.1.2"
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.17.7",
@@ -84,7 +85,7 @@
     "prettier-eslint": "13.0.0",
     "ts-jest": "25.5.1",
     "ts-node": "10.7.0",
-     "tslib": "2.3.1",
+    "tslib": "2.3.1",
     "tslint-config-prettier": "1.18.0",
     "typescript": "3.9.10"
   },


### PR DESCRIPTION
A fix for  ```
src/hooks/init/warnIfUpdateAvailable.ts:8:27 - error TS2307: Cannot find module 'lodash.template' or its corresponding type declarations.```
  ```
    8 import template = require('lodash.template');
```