### PR TITLE
:FC-1097: :zap: fix for issues caused by set-interval-async dependency update to v2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     'unicorn/prevent-abbreviations': 'off',
     'unicorn/no-abusive-eslint-disable': 0,
     'unicorn/import-index': 0,
+    'prefer-regex-literals': 0,
     'new-cap': 0,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17792,9 +17792,9 @@
       "dev": true
     },
     "set-interval-async": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/set-interval-async/-/set-interval-async-1.0.34.tgz",
-      "integrity": "sha512-wwDVmeXwOaumkZ7FizY0ux8N0fk4KM1Bq7DfBGHxjD/NSSjcvSlj4D6HHIxzu415QngUr0YW97TXl/s1Ou/BHQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/set-interval-async/-/set-interval-async-2.0.3.tgz",
+      "integrity": "sha512-8jJgvnhQYQc+XHzyKuJ2g4/0h4jPcT/q3x9VURk+AZohRKpcggcueNhPbS7wOXnamgpAn/enbGl4OnWXurVafg==",
       "requires": {
         "@babel/runtime": "7.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8986,14 +8986,23 @@
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
       "dev": true,
       "requires": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
-        "object.entries": "^1.1.2"
+        "object.entries": "^1.1.5",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "eslint-config-oclif": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@typescript-eslint/parser": "5.15.0",
     "babel-jest": "25.5.1",
     "eslint": "7.32.0",
-    "eslint-config-airbnb-base": "14.2.1",
+    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-oclif": "3.1.0",
     "eslint-config-oclif-typescript": "1.0.2",
     "eslint-config-prettier": "8.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "request": "^2.88.2",
     "request-promise-native": "^1.0.8",
     "semver": "^7.2.1",
-    "set-interval-async": "^1.0.30",
+    "set-interval-async": "^2.0.0",
     "systeminformation": "^5.3.1",
     "uuid": "8.3.2"
   },

--- a/src/view/deploy.view.ts
+++ b/src/view/deploy.view.ts
@@ -132,8 +132,10 @@ export class DeployView {
                     deployed = await checkIfLambdaIsDeployed();
                     /* istanbul ignore else */
                     if (deployed) {
-                      await clearIntervalAsync(timer);
-                      resolve();
+                      (async () => {
+                        await clearIntervalAsync(timer);
+                        resolve();
+                      })();
                     }
                   }, 3000);
                 });

--- a/src/view/deploy.view.ts
+++ b/src/view/deploy.view.ts
@@ -132,10 +132,9 @@ export class DeployView {
                     deployed = await checkIfLambdaIsDeployed();
                     /* istanbul ignore else */
                     if (deployed) {
-                      (async () => {
-                        await clearIntervalAsync(timer);
-                        resolve();
-                      })();
+                      // with the update to v2 the await clearIntervalAsync(timer) requires to be wrapped inside an immediately-invoke function expression or remove the await so that it resolves the timeout it causes because of not finishing the process
+                      clearIntervalAsync(timer);
+                      resolve();
                     }
                   }, 3000);
                 });

--- a/src/view/undeploy.view.ts
+++ b/src/view/undeploy.view.ts
@@ -121,10 +121,9 @@ export class UndeployView {
                     deployed = await waitUntilLambdaIsUndeployed();
                     /* istanbul ignore else */
                     if (deployed) {
-                      (async () => {
-                        await clearIntervalAsync(timer);
-                        resolve();
-                      })();
+                      // with the update to v2 the await clearIntervalAsync(timer) requires to be wrapped inside an immediately-invoke function expression or remove the await so that it resolves the timeout it causes because of not finishing the process
+                      clearIntervalAsync(timer);
+                      resolve();
                     }
                   }, 3000);
                 });

--- a/src/view/undeploy.view.ts
+++ b/src/view/undeploy.view.ts
@@ -121,8 +121,10 @@ export class UndeployView {
                     deployed = await waitUntilLambdaIsUndeployed();
                     /* istanbul ignore else */
                     if (deployed) {
-                      await clearIntervalAsync(timer);
-                      resolve();
+                      (async () => {
+                        await clearIntervalAsync(timer);
+                        resolve();
+                      })();
                     }
                   }, 3000);
                 });


### PR DESCRIPTION
with the update to v2 the `await clearIntervalAsync(timer)` requires to be wrapped inside an immediately-invoke function expression or remove the `await` so that it resolves the timeout it causes because of not finishing the process. for more details see here under **A word of caution** https://www.npmjs.com/package/set-interval-async